### PR TITLE
fix: adjustment of send response with underscore

### DIFF
--- a/src/main/java/it/gov/pagopa/message/controller/MessageCoreControllerImpl.java
+++ b/src/main/java/it/gov/pagopa/message/controller/MessageCoreControllerImpl.java
@@ -20,6 +20,6 @@ public class MessageCoreControllerImpl implements MessageCoreController {
         return messageCoreService.send(messageDTO)
                 .map(outcome -> Boolean.TRUE.equals(outcome) ?
                         ResponseEntity.ok(new SendResponseDTO("OK")) :
-                        ResponseEntity.status(HttpStatus.ACCEPTED).body(new SendResponseDTO("NO CHANNELS ENABLED")));
+                        ResponseEntity.status(HttpStatus.ACCEPTED).body(new SendResponseDTO("NO_CHANNELS_ENABLED")));
     }
 }

--- a/src/test/java/it/gov/pagopa/message/controller/MessageCoreControllerTest.java
+++ b/src/test/java/it/gov/pagopa/message/controller/MessageCoreControllerTest.java
@@ -56,7 +56,7 @@ class MessageCoreControllerTest {
                 .consumeWith(response -> {
                     String resultResponse = response.getResponseBody();
                     Assertions.assertNotNull(resultResponse);
-                    Assertions.assertEquals("{\"outcome\":\"NO CHANNELS ENABLED\"}",resultResponse);
+                    Assertions.assertEquals("{\"outcome\":\"NO_CHANNELS_ENABLED\"}",resultResponse);
                 });
     }
 


### PR DESCRIPTION
##### PULL REQUEST ####

### List of changes
 
<!--- Describe your changes in detail -->
 
Adjustment of send response with underscore in case of NO_CHANNELS_ENABLED

<!--- Why is this change required? What problem does it solve? -->
 
### Type of changes
 
- [ ] Add new feature
- [x] Update existing feature
- [ ] Remove existing feature
- [ ] Other changes
 
### Does this introduce a breaking change?
 
- [ ] Yes
- [x] No
 
### Other information
 
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->